### PR TITLE
Fly Deploy workflow is triggered by a successful Rust build and test

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -2,13 +2,18 @@
 
 name: Fly Deploy
 on:
-  push:
+  workflow_run:
+    workflows: [Rust]
     branches:
       - main
+    types:
+      - completed
+
 jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The "Fly Deploy" workflow is now triggered by a successful run of the "Rust" workflow.  This ensures that the deploy is only made after successfully building and testing the project.