### PR TITLE
Add linter step "cargo clippy" to the Rust CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,5 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
+    - name: Run Clippy
+      run: cargo clippy --verbose
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
Add `cargo clippy` as a linter step  to the Rust CI.